### PR TITLE
Deploy with railway

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [CORS-Anywhere](https://www.npmjs.com/package/cors-anywhere) is a Node.js package that adds [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers to a proxied request. This is useful when the API provider does not natively support CORS. Without altering the headers, a request to such a provider would cause an error and prevent the request from being fulfilled.
 
-**Tip:** You can test out the server in this repo locally by using port 3000 in your application and prepending `https://private-cors-server.up.railway.app/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). However, if you want to use for a hosted website, then follow the implementation steps below.
+**Tip:** You can test out the server in this repo locally by using ports `3000` or `5000` in your application and prepending `https://private-cors-server.up.railway.app/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). However, if you want to use for a hosted website, then follow the implementation steps below.
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [CORS-Anywhere](https://www.npmjs.com/package/cors-anywhere) is a Node.js package that adds [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers to a proxied request. This is useful when the API provider does not natively support CORS. Without altering the headers, a request to such a provider would cause an error and prevent the request from being fulfilled.
 
-**Tip:** You can test out the server in this repo locally by using port 3000 in your application and prepending `https://us-central1-private-cors-server.cloudfunctions.net/proxy/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). However, if you want to use for a hosted website, then follow the implementation steps below.
+**Tip:** You can test out the server in this repo locally by using port 3000 in your application and prepending `https://private-cors-server.up.railway.app/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). However, if you want to use for a hosted website, then follow the implementation steps below.
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,6 @@
 
 **Tip:** You can test out the server in this repo locally by using port 3000 in your application and prepending `https://us-central1-private-cors-server.cloudfunctions.net/proxy/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). However, if you want to use for a hosted website, then follow the implementation steps below.
 
-
-# `IMPORTANT NOTICE`
-
-### There are some issues with the remote-hosted instance of `cors-server` using Firebase functions. It only works when locally hosted for now.
-
-### It is advised to implement the Heroku version of this server until the issues are resolved. The Firebase version should be operational well before Heroku [withdraws](https://devcenter.heroku.com/articles/free-dyno-hours) provision of free Dynos on 28th of November 2022.
-
-### To do so, follow the `README` in the `heroku` directory. It works similarly to before, just move all of the files contained therein up a level (i.e. to root) before deployment to Heroku.
-
 ## Implementation
 
 The server can be implemented in one of three ways. Is is recommended to use Railway currently.

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@
 
 ## Implementation
 
-Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:
+The server can be implemented in one of three ways. Is is recommended to use Railway currently.
 
-1. Fork this repository.
-2. Within [index.js](https://github.com/Isoaxe/cors-server/blob/master/functions/index.js#L5), replace the website URLs in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
-3. Navigate to the `functions` directory from the terminal and run `npm install`.
-4. Create a new [Firebase](https://firebase.google.com/) account if you don't already have one.
-5. Install the Firebase CLI by running `npm install -g firebase-tools`.
-6. Log into Firebase using your Google account credentials with `firebase login` in the terminal.
-7. From the Firebase console in your browser, create a new project. Give it a name and `project-id`.
-8. Replace the value of the `default` field in [`.firebaserc`](https://github.com/Isoaxe/cors-server/blob/master/.firebaserc#L3) with your `project-id`.
-9. From the bottom-left of the Firebase browser console, upgrade your billing plan from Spark (free) to Blaze (paid). Don't worry though, so long as you don't operate an open proxy or make a huge amount of requests it should be fine. You should also set up billing alerts and a cutoff just to be sure. There is a [generous](https://firebase.google.com/pricing) free tier of 2 million cloud function invocations per month in any case.
-10. From the terminal, navigate to the `functions` directory and `npm run deploy`. Your function will deploy to `https://<region>-<project-id>.cloudfunctions.net/proxy`. In my case, it was `https://us-central1-private-cors-server.cloudfunctions.net/proxy`.
-11. Prepend the API request in your application code with this URL [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). That's it, you've implemented the server!
+### Heroku
+
+Navigate to the `heroku` directory and follow the steps within the `README.md` therein. Note that Heroku will [withdraw](https://devcenter.heroku.com/articles/free-dyno-hours) provision of free Dynos on 28th of November 2022. The [cost](https://www.heroku.com/pricing) will be $7 per Dyno per month thereafter.
+
+### Firebase
+
+Navigate to the `functions` directory and follow the steps within the `README.md` therein. Note that there continues to be some issues when hosting remote using Firebase functions. Until these are resolved, it is advised that you use the `railway` implementation.
+
+### Railway
+
+Navigate to the `railway` directory and follow the steps within the `README.md` therein. This is the recommended implementation due to the issues outlined in the others above.

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,21 @@
+# `IMPORTANT NOTICE`
+
+### There are some issues with the remote-hosted instance of `cors-server` using Firebase functions. It only works when locally hosted for now.
+
+### It is advised to implement the Railway version of this server instead. To do so, follow the `README` in the `railway` directory.
+
+## Implementation using Firebase
+
+Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:
+
+1. Fork this repository.
+2. Within [index.js](https://github.com/Isoaxe/cors-server/blob/master/functions/index.js#L5), replace the website URLs in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
+3. Navigate to the `functions` directory from the terminal and run `npm install`.
+4. Create a new [Firebase](https://firebase.google.com/) account if you don't already have one.
+5. Install the Firebase CLI by running `npm install -g firebase-tools`.
+6. Log into Firebase using your Google account credentials with `firebase login` in the terminal.
+7. From the Firebase console in your browser, create a new project. Give it a name and `project-id`.
+8. Replace the value of the `default` field in [`.firebaserc`](https://github.com/Isoaxe/cors-server/blob/master/.firebaserc#L3) with your `project-id`.
+9. From the bottom-left of the Firebase browser console, upgrade your billing plan from Spark (free) to Blaze (paid). Don't worry though, so long as you don't operate an open proxy or make a huge amount of requests it should be fine. You should also set up billing alerts and a cutoff just to be sure. There is a [generous](https://firebase.google.com/pricing) free tier of 2 million cloud function invocations per month in any case.
+10. From the terminal, navigate to the `functions` directory and `npm run deploy`. Your function will deploy to `https://<region>-<project-id>.cloudfunctions.net/proxy`. In my case, it was `https://us-central1-private-cors-server.cloudfunctions.net/proxy`.
+11. Prepend the API request in your application code with this URL [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L6). That's it, you've implemented the server!

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -1,9 +1,9 @@
-## Implementation
+## Implementation using Heroku
 
 Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:
 
 1. Clone or fork this repository.
-2. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
+2. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/heroku/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
 3. Now simply upload / push the repo to a hosting provider. I used a free [Heroku](https://id.heroku.com/login) account to create a Node.js app. This can be done without any knowledge of Node, and only a basic familiarity with Git and the command line. Just follow the excellent documentation [here](https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment) (steps 3 to 6 inclusive can be ignored).
 4. Prepend the API request in your application code with the server URL as generated in the previous step [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L5). That's it, you've implemented the server!
 

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -1,10 +1,3 @@
-# CORS-Anywhere Server
-
-[CORS-Anywhere](https://www.npmjs.com/package/cors-anywhere) is a Node.js package that adds [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers to a proxied request. This is useful when the API provider does not natively support CORS. Without altering the headers, a request to such a provider would cause an error and prevent the request from being fulfilled.
-
-**Tip:** You can test out the server in this repo locally by using port 3000 in your application and prepending `https://private-cors-server.herokuapp.com/` to your API request [like this](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L5). However, if you want to use for a hosted website, then follow the implementation steps below.
-
-
 ## Implementation
 
 Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -1,3 +1,7 @@
+# `IMPORTANT NOTICE`
+
+### Heroku will [withdraw](https://devcenter.heroku.com/articles/free-dyno-hours) provision of free Dynos on 28th of November 2022. The [cost](https://www.heroku.com/pricing) will be $7 per Dyno per month after that.
+
 ## Implementation using Heroku
 
 Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -6,7 +6,7 @@
 
 Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:
 
-1. Clone or fork this repository.
+1. Fork this repository.
 2. Move all of the files in this directory (except this `README`) to root. Heroku only accepts deployment from the root directory and the `master` or `main` branch.
 3. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/heroku/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
 4. Now simply upload / push the repo to a hosting provider. I used a free [Heroku](https://id.heroku.com/login) account to create a Node.js app. This can be done without any knowledge of Node, and only a basic familiarity with Git and the command line. Just follow the excellent documentation [here](https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment) (steps 3 to 6 inclusive can be ignored).

--- a/heroku/README.md
+++ b/heroku/README.md
@@ -3,9 +3,10 @@
 Implementation of a basic CORS-Anywhere server is very straightforward. Simply do the following:
 
 1. Clone or fork this repository.
-2. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/heroku/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
-3. Now simply upload / push the repo to a hosting provider. I used a free [Heroku](https://id.heroku.com/login) account to create a Node.js app. This can be done without any knowledge of Node, and only a basic familiarity with Git and the command line. Just follow the excellent documentation [here](https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment) (steps 3 to 6 inclusive can be ignored).
-4. Prepend the API request in your application code with the server URL as generated in the previous step [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L5). That's it, you've implemented the server!
+2. Move all of the files in this directory (except this `README`) to root. Heroku only accepts deployment from the root directory and the `master` or `main` branch.
+3. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/heroku/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
+4. Now simply upload / push the repo to a hosting provider. I used a free [Heroku](https://id.heroku.com/login) account to create a Node.js app. This can be done without any knowledge of Node, and only a basic familiarity with Git and the command line. Just follow the excellent documentation [here](https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment) (steps 3 to 6 inclusive can be ignored).
+5. Prepend the API request in your application code with the server URL as generated in the previous step [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L5). That's it, you've implemented the server!
 
 **Tip:** If hosting on Heroku, a Procfile has already been created in this repository. This instructs the Heroku Node app on how to start the server.
 

--- a/railway/README.md
+++ b/railway/README.md
@@ -1,0 +1,15 @@
+## Implementation using Railway
+
+_Note:_ Implementing the server via Railway uses the same code as with Heroku, so there is no need to duplicate it within this directory.
+
+1. Fork this repository.
+2. Within [server.js](https://github.com/Isoaxe/cors-server/blob/master/heroku/server.js#L9), replace the website string in the `originWhitelist` array with the web address(es) that you want to authorise. You can keep the first string here as is for local testing (assuming you're using port 3000).
+3. Create a [Railway](https://railway.app) account.
+4. Verify the account by connecting to GitHub. This gives $5 free credit per month. No payment card required.
+5. Go to 'New Project' -> 'Deploy from GitHub repo'. Authorise Railway to access your GitHub project.
+6. Click 'deploy now' on the authorised app.
+7. It will fail. Go to Settings for the deployment in the Railway browser console and change the root directory to `/heroku`.
+8. Click 'enable' under the 'Domains' subsection to assign a public URL to the server and expose it to the internet. It will be of the form `https://private-cors-server.up.railway.app/`.
+9. Prepend the API request in your application code with the server URL as generated in the previous step [like so](https://github.com/Isoaxe/ravenous/blob/master/src/util/searchYelp.js#L5). That's it, you've implemented the server!
+
+**Tip:** Railway uses a Procfile just like Heroku. This has already been created in this repository. This instructs the Railway Node app on how to start the server.


### PR DESCRIPTION
Just needed to edit the `README`s. Can use the same code as with Heroku.

Now there is a main `README` that gives a brief summary of each of the three options. This is a much clearer way to arrange the instructions.

For each directory (`functions`, `heroku` and `railway`), there is a separate `README` outlining how each one should be implemented. For the two former ones, an `Important Notice` has been retained to warn of the drawbacks (namely the remaining issues with Firebase and Herokus free tier expiring).